### PR TITLE
Fix typo in combine_data message

### DIFF
--- a/combine_data.py
+++ b/combine_data.py
@@ -30,7 +30,7 @@ def combine(dir, combined_pfs=None, combined_asp=None, combined_lab=None, combin
     
     # Check if no dfs to combine
     if not dfs_to_combine:
-        print('No vauid dataframes provided. Skipping combination.')
+        print('No valid dataframes provided. Skipping combination.')
         return
 
     combined_cms = pd.concat(dfs_to_combine, ignore_index=True)


### PR DESCRIPTION
## Summary
- fix a typo in combine_data warning message

## Testing
- `python3 -m py_compile combine_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68402c1629a88333a9f2e9f8315ea5ec